### PR TITLE
Catch exceptions when trying to add StrongholdGeneral

### DIFF
--- a/stronghold/julia_scripts/sh_startup.jl
+++ b/stronghold/julia_scripts/sh_startup.jl
@@ -1,3 +1,7 @@
 using Pkg
 
-Pkg.Registry.add(RegistrySpec(name= "StrongHoldGeneral", path="/opt/julia/share/julia/registries/StrongHoldGeneral"))
+try
+    Pkg.Registry.add(RegistrySpec(name="StrongHoldGeneral", path="/opt/julia/share/julia/registries/StrongHoldGeneral"))
+catch e
+    @warn("ignoring exception: ", e)
+end


### PR DESCRIPTION
Currently, if adding `StrongholdGeneral` fails for any reason, a fatal error is thrown, and Julia exits immediately. Thus, Julia with this startup script becomes unusable if, for any reason, there is an error when adding `StrongholdGeneral`.

This pull request wraps the `Pkg.Registry.add` command inside a `try`-`catch`-`end` block. If an error occurs when adding `StrongholdGeneral`, a warning is issued, but Julia does not exit.

cc: @mcmcgrath13 @mirestrepo 