### PR TITLE
Add fonts with broad glyph support for PDF export

### DIFF
--- a/jupyterhub/datasci/Dockerfile
+++ b/jupyterhub/datasci/Dockerfile
@@ -26,6 +26,17 @@ RUN chmod +x /usr/local/bin/ssh-keyreg
 COPY ./scripts/gitconfig /usr/local/bin/gitconfig
 RUN chmod +x /usr/local/bin/gitconfig
 
+# Install Noto Sans Mono and TeX Gyre Pagella fonts on the system
+RUN mkdir /home/jovyan/.fonts && cd /home/jovyan/.fonts && \
+    wget https://noto-website-2.storage.googleapis.com/pkgs/NotoSansMono-unhinted.zip && \
+    unzip NotoSansMono-unhinted.zip && \
+    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-bold.otf && \
+    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-bolditalic.otf && \
+    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-italic.otf && \
+    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-regular.otf && \
+    fc-cache -f -v && \
+    mktexlsr
+
 USER $NB_UID
 
 RUN pip install --upgrade pip

--- a/jupyterhub/misc_files/style_jupyter.tplx
+++ b/jupyterhub/misc_files/style_jupyter.tplx
@@ -5,8 +5,8 @@
     \usepackage[breakable]{tcolorbox}
     \usepackage{fontspec}
     \usepackage{mathpazo}
-    \setmainfont{DejaVu Math TeX Gyre}
-    \setmonofont{Liberation Mono}
+    \setmainfont{TeX Gyre Pagella}
+    \setmonofont{Noto Sans Mono}
     \tcbset{nobeforeafter} % prevents tcolorboxes being placing in paragraphs
     \usepackage{float}
     \floatplacement{figure}{H} % forces figures to be placed at the correct location


### PR DESCRIPTION
I wasn't able to build this on my machine to test these additions (for reasons that were unrelated to the changes), but I did test them on top of the minimal-jupyter image, and it worked great. The reason that the original scripts didn't work is that I forgot that `mktexlsr` has to be run (as root) for TeX to recognize the system fonts.