### PR TITLE
Support image resizing in PDF output

### DIFF
--- a/jupyterhub/misc_files/data_style_jupyter.tplx
+++ b/jupyterhub/misc_files/data_style_jupyter.tplx
@@ -12,6 +12,11 @@
     \usepackage{float}
     \floatplacement{figure}{H} % forces figures to be placed at the correct location
     ((( super() )))
+    \makeatletter % next four lines allow image resizing via pandoc syntax: ![](img.png){width=50%}
+    \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+    \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+    \makeatother
+    \setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
 ((*- endblock packages -*))
 
 ((*- block definitions -*))


### PR DESCRIPTION
See https://github.com/jgm/pandoc/issues/4384 for discussion of why these lines are necessary to allow image resizing. This improvement is unrelated to the other PRs, and I have checked that it works (both on a minimal Jupyter docker image and by directly editing a TeX file in the current JupyterHub deployment), so there shouldn't be any issues.

Images were the last thing on my list for helping the students prepare their homework submissions. I now have a set of instructions for them that I consider to be sufficiently complete, and I believe that all the Dockerfile code has been figured out to make it work smoothly. Thanks!