### PR TITLE
Template spacing

### DIFF
--- a/jupyterhub/misc_files/data_style_jupyter.tplx
+++ b/jupyterhub/misc_files/data_style_jupyter.tplx
@@ -12,6 +12,11 @@
     \usepackage{float}
     \floatplacement{figure}{H} % forces figures to be placed at the correct location
     ((( super() )))
+    \makeatletter % next four lines allow image resizing via pandoc syntax: ![](img.png){width=50%}
+    \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+    \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+    \makeatother
+    \setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
 ((*- endblock packages -*))
 
 ((*- block definitions -*))

--- a/jupyterhub/misc_files/data_style_jupyter.tplx
+++ b/jupyterhub/misc_files/data_style_jupyter.tplx
@@ -3,14 +3,11 @@
 
 ((*- block packages -*))
     \usepackage[breakable]{tcolorbox}
-    \usepackage{fontspec}
+    \usepackage{parskip} % Stop auto-indenting (to mimic markdown behaviour)
+    \usepackage[no-math]{fontspec}
     \usepackage{mathpazo}
-    %\usepackage{noto-mono}
     \setmainfont{TeX Gyre Pagella}
     \setmonofont{Noto Sans Mono}
-    \tcbset{nobeforeafter} % prevents tcolorboxes being placing in paragraphs
-    \usepackage{float}
-    \floatplacement{figure}{H} % forces figures to be placed at the correct location
     ((( super() )))
     \makeatletter % next four lines allow image resizing via pandoc syntax: ![](img.png){width=50%}
     \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
@@ -110,9 +107,12 @@
     ((*- endblock style_colors *))
     
     % prompt
+    \makeatletter
+    \newcommand{\boxspacing}{\kern\kvtcb@left@rule\kern\kvtcb@boxsep}
+    \makeatother
     ((*- block style_prompt *))
     \newcommand{\prompt}[4]{
-        \llap{{\color{#2}[#3]: #4}}\vspace{-1.25em}
+        \ttfamily\llap{{\color{#2}[#3]:\hspace{3pt}#4}}\vspace{-\baselineskip}
     }
     ((* endblock style_prompt *))
     
@@ -123,7 +123,7 @@
 %===============================================================================
 
 ((* block input scoped *))
-    ((( draw_cell(cell.source | highlight_code(strip_verbatim=True), cell, 'In', 'incolor', '\\hspace{4pt}') )))
+    ((( draw_cell(cell.source | highlight_code(strip_verbatim=True), cell, 'In', 'incolor', '\\boxspacing') )))
 ((* endblock input *))
 
 
@@ -138,7 +138,7 @@
 ((* block execute_result scoped *))
     ((*- for type in output.data | filter_data_type -*))
         ((*- if type in ['text/plain']*))
-            ((( draw_cell(output.data['text/plain'] | wrap_text(charlim) | escape_latex, cell, 'Out', 'outcolor', '\\hspace{3.5pt}') )))
+            ((( draw_cell(output.data['text/plain'] | wrap_text(charlim) | escape_latex | ansi2latex, cell, 'Out', 'outcolor', '\\boxspacing') )))
         ((* else -*))
             ((( " " )))
             ((( draw_prompt(cell, 'Out', 'outcolor','') )))((( super() )))
@@ -148,7 +148,7 @@
 
 ((* block stream *))
     \begin{Verbatim}[commandchars=\\\{\}]
-((( output.text | wrap_text(charlim) | escape_latex | ansi2latex -)))
+((( output.text | wrap_text(charlim) | escape_latex | strip_trailing_newline | ansi2latex )))
     \end{Verbatim}
 ((* endblock stream *))
 
@@ -162,7 +162,7 @@
 ((* macro draw_cell(text, cell, prompt, prompt_color, extra_space) -*))
 ((*- if prompt == 'In' -*))
 ((*- set style = "breakable, size=fbox, boxrule=1pt, pad at break*=1mm,colback=cellbackground, colframe=cellborder"-*))
-((*- else -*))((*- set style = "breakable, boxrule=.5pt, size=fbox, pad at break*=1mm, opacityfill=0"-*))((*-  endif -*))
+((*- else -*))((*- set style = "breakable, size=fbox, boxrule=.5pt, pad at break*=1mm, opacityfill=0"-*))((*-  endif -*))
 
 \begin{tcolorbox}[((( style )))]
 (((- draw_prompt(cell, prompt, prompt_color, extra_space) )))


### PR DESCRIPTION
There was an incompatibility between the template version we were using and the version of nbconvert that the Docker image runs (5.5.1 vs 5.6.0). This doesn't cause anything to break, but it does result in weird vertical spacing throughout the document.